### PR TITLE
BAU: Invite the support person to support calendar events

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -159,7 +159,10 @@ function createSupportEvents() {
       } // loop over events
 
       var supportEventTitle = supportPerson + " on support";
-      calendar.createAllDayEvent(supportEventTitle, supportDate,{description: slackEmails[supportPerson]});
+      calendar.createAllDayEvent(supportEventTitle, supportDate, {
+        description: slackEmails[supportPerson],
+        guests: slackEmails[supportPerson]
+      });
       Logger.log("User " + supportPerson + " " + supportDate);
 
       // If PagerDuty is configured, and the support day is in the future, 


### PR DESCRIPTION
# What is the change?

Add the support person to the calendar event as a guest

# Why are we making this change?

So support engineers  are notified of new support rota events 


# From the docs

https://developers.google.com/apps-script/reference/calendar/calendar-app#createAllDayEvent(String,Date)